### PR TITLE
Fixing translation URL with 404 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ I really like working on Gnome-Pie — and you can help improving it! There are 
 
 ### Translate Gnome-Pie!
 
-This is really easy: [There is an how-to available](http://schneegans.github.io/news/2015/08/07/translate-gnome-pie/)!
+This is really easy: [There is an how-to available](http://schneegans.github.io/news/2015/08/07/translate-gnome-pie)!
 
 ### Donate!
 


### PR DESCRIPTION
I just noticed that the translation link on README is giving an 404 error, and removing the trailing slash resolves it.

Note: The last link inside the blog post is also giving an bad URL.